### PR TITLE
Infer parameters count from message size (uint16 overflow bypass) #2

### DIFF
--- a/src/Messages/ParameterDescription.php
+++ b/src/Messages/ParameterDescription.php
@@ -33,7 +33,7 @@ class ParameterDescription implements BackendMessageInterface
             $buffer->readUInt16BE();
 
             // Instead, infer parameter count by remaining size of message
-            $parameterCount = $buffer->getSize() / 4;
+            $parameterCount = $buffer->getRemainingSize() / 4;
             if (!\is_int($parameterCount)) {
                 throw new InvalidMessageFormatException($this->getName(), null);
             }


### PR DESCRIPTION
PostgreSQL accepts preparing a statement with more than 65535 parameters and only fails when executing it through the extended protocol.